### PR TITLE
feat: add archive feature

### DIFF
--- a/phone-test/src/App.tsx
+++ b/phone-test/src/App.tsx
@@ -1,7 +1,7 @@
 import './App.css';
 import { createBrowserRouter, createRoutesFromElements, Route } from 'react-router-dom';
 import { LoginPage } from './pages/Login/Login';
-import { CallsListPage } from './pages/Call/CallsList';
+import CallsListPage from './pages/Call';
 import { CallDetailsPage } from './pages/Call/CallDetails';
 import { Tractor } from '@aircall/tractor';
 

--- a/phone-test/src/auth/index.ts
+++ b/phone-test/src/auth/index.ts
@@ -1,9 +1,9 @@
-import { ApolloClient, InMemoryCache } from '@apollo/client';
-import { authLink, httpLink } from './links';
+import { ApolloClient, InMemoryCache, from } from '@apollo/client';
+import { errorLink, splitLink } from './links';
 
 const client = new ApolloClient({
   cache: new InMemoryCache(),
-  link: authLink.concat(httpLink)
+  link: from([errorLink, splitLink])
 });
 
 export default client;

--- a/phone-test/src/gql/mutations/archiveCall.ts
+++ b/phone-test/src/gql/mutations/archiveCall.ts
@@ -1,0 +1,12 @@
+import { gql } from '@apollo/client';
+import { CALL_FIELDS } from '../fragments';
+
+export const ARCHIVE_CALL = gql`
+  ${CALL_FIELDS}
+
+  mutation archiveCall($id: ID!) {
+    archiveCall(id: $id) {
+      ...CallFields
+    }
+  }
+`;

--- a/phone-test/src/gql/mutations/index.ts
+++ b/phone-test/src/gql/mutations/index.ts
@@ -1,2 +1,3 @@
 export * from './login';
 export * from './refreshToken';
+export * from './archiveCall';

--- a/phone-test/src/gql/subscriptions/index.ts
+++ b/phone-test/src/gql/subscriptions/index.ts
@@ -1,0 +1,1 @@
+export * from './update';

--- a/phone-test/src/gql/subscriptions/update.ts
+++ b/phone-test/src/gql/subscriptions/update.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client';
+
+export const SUBSCRIPTION_QUERY = gql`
+  subscription onUpdatedCall {
+    onUpdatedCall {
+      id
+      direction
+      is_archived
+    }
+  }
+`;

--- a/phone-test/src/pages/Call/CallItem.tsx
+++ b/phone-test/src/pages/Call/CallItem.tsx
@@ -5,7 +5,8 @@ import {
   Box,
   DiagonalDownOutlined,
   DiagonalUpOutlined,
-  Button
+  Button,
+  useToast
 } from '@aircall/tractor';
 import { formatDate, formatDuration } from '../../helpers/dates';
 import { useNavigate } from 'react-router-dom';
@@ -13,6 +14,8 @@ import { useMutation } from '@apollo/client';
 import { ARCHIVE_CALL } from '../../gql/mutations/archiveCall';
 
 const CallItem = ({ call }: { call: Call }) => {
+  const { showToast } = useToast();
+
   const icon = call.direction === 'inbound' ? DiagonalDownOutlined : DiagonalUpOutlined;
   const title =
     call.call_type === 'missed'
@@ -72,11 +75,19 @@ const CallItem = ({ call }: { call: Call }) => {
           onClick={e => {
             e.stopPropagation();
             archiveCall({ variables: { id: call.id } })
-              .then(data => {
-                console.log('archive data', data);
+              .then(() => {
+                showToast({
+                  variant: 'success',
+                  dismissIn: 3000,
+                  message: 'Archive call successful'
+                });
               })
-              .catch(err => {
-                console.log('error', err);
+              .catch(() => {
+                showToast({
+                  variant: 'error',
+                  dismissIn: 3000,
+                  message: 'Archive call failed'
+                });
               });
           }}
           variant={call.is_archived ? 'destructive' : 'instructive'}

--- a/phone-test/src/pages/Call/CallItem.tsx
+++ b/phone-test/src/pages/Call/CallItem.tsx
@@ -4,10 +4,13 @@ import {
   Typography,
   Box,
   DiagonalDownOutlined,
-  DiagonalUpOutlined
+  DiagonalUpOutlined,
+  Button
 } from '@aircall/tractor';
 import { formatDate, formatDuration } from '../../helpers/dates';
 import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@apollo/client';
+import { ARCHIVE_CALL } from '../../gql/mutations/archiveCall';
 
 const CallItem = ({ call }: { call: Call }) => {
   const icon = call.direction === 'inbound' ? DiagonalDownOutlined : DiagonalUpOutlined;
@@ -26,6 +29,8 @@ const CallItem = ({ call }: { call: Call }) => {
   const handleCallOnClick = (callId: string) => {
     navigate(`/calls/${callId}`);
   };
+
+  const [archiveCall] = useMutation(ARCHIVE_CALL);
 
   return (
     <Box
@@ -61,6 +66,24 @@ const CallItem = ({ call }: { call: Call }) => {
       </Grid>
       <Box px={4} py={2}>
         <Typography variant="caption">{notes}</Typography>
+      </Box>
+      <Box p={10}>
+        <Button
+          onClick={e => {
+            e.stopPropagation();
+            archiveCall({ variables: { id: call.id } })
+              .then(data => {
+                console.log('archive data', data);
+              })
+              .catch(err => {
+                console.log('error', err);
+              });
+          }}
+          variant={call.is_archived ? 'destructive' : 'instructive'}
+          size="xSmall"
+        >
+          {call.is_archived ? 'Unarchive Call' : ' Archive call'}
+        </Button>
       </Box>
     </Box>
   );

--- a/phone-test/src/pages/Call/index.ts
+++ b/phone-test/src/pages/Call/index.ts
@@ -1,0 +1,1 @@
+export { CallsListPage as default } from './CallsList';


### PR DESCRIPTION
### Description :

**1. Added Archive/Unarchive Button in CallItem Card:**
- Introduced a new button within the Call card UI to facilitate archiving and unarchiving of calls.
- This feature provides users with a convenient way to manage the archive status of individual calls directly from the call card.

**2. Implemented Archive call Filter Button:**
 - Introduced a filter button on call list page for efficiently organizing calls based on their archive status.
- Users can now easily toggle between viewing archived and unarchived calls, enhancing the overall call management experience.

### Changelog :

1. Added a WebSocket link to enable subscription functionality within the application.
2. Implemented a split link to determine whether a query should be directed to:
     - WebSocket Link (for subscription-related queries) 
     - HttpLink/AuthLink (for other non-subscription queries)
3. Added archive call mutation. 
4. Added onUpdateCall subscription query.
5. Leveraged the useSubscription hook in the CallList page to actively listen to changes in the archive status of calls.


### Feature Demo :

https://github.com/Gurmanjot/frontend-test/assets/41263104/8a7a28a8-1e3f-4981-ab6b-8119320fb3d7


